### PR TITLE
Update FSF address in license and license headers

### DIFF
--- a/orocos_bfl/COPYING
+++ b/orocos_bfl/COPYING
@@ -2,7 +2,7 @@
 		       Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -485,7 +485,7 @@ convey the exclusion of warranty; and each file should have at least the
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/orocos_bfl/examples/compare_filters/nonlinearanalyticconditionalgaussianmobile.cpp
+++ b/orocos_bfl/examples/compare_filters/nonlinearanalyticconditionalgaussianmobile.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "nonlinearanalyticconditionalgaussianmobile.h"

--- a/orocos_bfl/examples/compare_filters/nonlinearanalyticconditionalgaussianmobile.h
+++ b/orocos_bfl/examples/compare_filters/nonlinearanalyticconditionalgaussianmobile.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 

--- a/orocos_bfl/examples/compare_filters/test_compare_filters.cpp
+++ b/orocos_bfl/examples/compare_filters/test_compare_filters.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/examples/discrete_filter/conditionalUniformMeasPdf1d.cpp
+++ b/orocos_bfl/examples/discrete_filter/conditionalUniformMeasPdf1d.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "conditionalUniformMeasPdf1d.h"

--- a/orocos_bfl/examples/discrete_filter/conditionalUniformMeasPdf1d.h
+++ b/orocos_bfl/examples/discrete_filter/conditionalUniformMeasPdf1d.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __CONDITIONAL_UNIFORM_PDF__

--- a/orocos_bfl/examples/discrete_filter/test_discrete_filter.cpp
+++ b/orocos_bfl/examples/discrete_filter/test_discrete_filter.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/examples/linear_kalman/test_linear_kalman.cpp
+++ b/orocos_bfl/examples/linear_kalman/test_linear_kalman.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/examples/mobile_robot.cpp
+++ b/orocos_bfl/examples/mobile_robot.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "mobile_robot.h"

--- a/orocos_bfl/examples/mobile_robot.h
+++ b/orocos_bfl/examples/mobile_robot.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef MOBILE_ROBOT_HPP

--- a/orocos_bfl/examples/mobile_robot_wall_cts.h
+++ b/orocos_bfl/examples/mobile_robot_wall_cts.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __MOBILE_ROBOT_CTS_

--- a/orocos_bfl/examples/nonlinear_kalman/test_nonlinear_kalman.cpp
+++ b/orocos_bfl/examples/nonlinear_kalman/test_nonlinear_kalman.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/examples/nonlinear_particle/nonlinearMeasurementPdf.cpp
+++ b/orocos_bfl/examples/nonlinear_particle/nonlinearMeasurementPdf.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "nonlinearMeasurementPdf.h"

--- a/orocos_bfl/examples/nonlinear_particle/nonlinearMeasurementPdf.h
+++ b/orocos_bfl/examples/nonlinear_particle/nonlinearMeasurementPdf.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 

--- a/orocos_bfl/examples/nonlinear_particle/nonlinearSystemPdf.cpp
+++ b/orocos_bfl/examples/nonlinear_particle/nonlinearSystemPdf.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "nonlinearSystemPdf.h"

--- a/orocos_bfl/examples/nonlinear_particle/nonlinearSystemPdf.h
+++ b/orocos_bfl/examples/nonlinear_particle/nonlinearSystemPdf.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 

--- a/orocos_bfl/examples/nonlinear_particle/test_nonlinear_particle.cpp
+++ b/orocos_bfl/examples/nonlinear_particle/test_nonlinear_particle.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/examples/nonlinearanalyticconditionalgaussianmobile.cpp
+++ b/orocos_bfl/examples/nonlinearanalyticconditionalgaussianmobile.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "nonlinearanalyticconditionalgaussianmobile.h"

--- a/orocos_bfl/examples/nonlinearanalyticconditionalgaussianmobile.h
+++ b/orocos_bfl/examples/nonlinearanalyticconditionalgaussianmobile.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 

--- a/orocos_bfl/examples/smoother/test_kalman_smoother.cpp
+++ b/orocos_bfl/examples/smoother/test_kalman_smoother.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/examples/smoother/test_nonlinear_smoother.cpp
+++ b/orocos_bfl/examples/smoother/test_nonlinear_smoother.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 
 /* Demonstration program for the Bayesian Filtering Library.
    Mobile robot localization with respect to wall with different possibilities for filter

--- a/orocos_bfl/src/bfl_constants.h
+++ b/orocos_bfl/src/bfl_constants.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __BFL_CONSTANTS_H__
 #define __BFL_CONSTANTS_H__

--- a/orocos_bfl/src/bfl_err.h
+++ b/orocos_bfl/src/bfl_err.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 // Error codes

--- a/orocos_bfl/src/bindings/rtt/SampleComposition.hpp
+++ b/orocos_bfl/src/bindings/rtt/SampleComposition.hpp
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/filter/EKparticlefilter.cpp
+++ b/orocos_bfl/src/filter/EKparticlefilter.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "EKparticlefilter.h"

--- a/orocos_bfl/src/filter/EKparticlefilter.h
+++ b/orocos_bfl/src/filter/EKparticlefilter.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __EK_PARTICLE_FILTER__

--- a/orocos_bfl/src/filter/SRiteratedextendedkalmanfilter.cpp
+++ b/orocos_bfl/src/filter/SRiteratedextendedkalmanfilter.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "SRiteratedextendedkalmanfilter.h"
 #include "../model/linearanalyticmeasurementmodel_gaussianuncertainty_implicit.h"

--- a/orocos_bfl/src/filter/SRiteratedextendedkalmanfilter.h
+++ b/orocos_bfl/src/filter/SRiteratedextendedkalmanfilter.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __SR_ITERATED_EXTENDED_KALMAN_FILTER__

--- a/orocos_bfl/src/filter/asirfilter.cpp
+++ b/orocos_bfl/src/filter/asirfilter.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 // $Id$
 

--- a/orocos_bfl/src/filter/asirfilter.h
+++ b/orocos_bfl/src/filter/asirfilter.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 // $Id$

--- a/orocos_bfl/src/filter/bootstrapfilter.cpp
+++ b/orocos_bfl/src/filter/bootstrapfilter.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 // $Id$
 

--- a/orocos_bfl/src/filter/bootstrapfilter.h
+++ b/orocos_bfl/src/filter/bootstrapfilter.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 // $Id$

--- a/orocos_bfl/src/filter/extendedkalmanfilter.cpp
+++ b/orocos_bfl/src/filter/extendedkalmanfilter.cpp
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "extendedkalmanfilter.h"
 

--- a/orocos_bfl/src/filter/extendedkalmanfilter.h
+++ b/orocos_bfl/src/filter/extendedkalmanfilter.h
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __EXTENDED_KALMAN_FILTER__

--- a/orocos_bfl/src/filter/filter.cpp
+++ b/orocos_bfl/src/filter/filter.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "filter.h"

--- a/orocos_bfl/src/filter/filter.h
+++ b/orocos_bfl/src/filter/filter.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/filter/histogramfilter.cpp
+++ b/orocos_bfl/src/filter/histogramfilter.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "histogramfilter.h"
 #include <cmath>

--- a/orocos_bfl/src/filter/histogramfilter.h
+++ b/orocos_bfl/src/filter/histogramfilter.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __HISTOGRAM_FILTER__

--- a/orocos_bfl/src/filter/innovationCheck.cpp
+++ b/orocos_bfl/src/filter/innovationCheck.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "innovationCheck.h"
 #include "../wrappers/rng/rng.h" // Wrapper around several rng libraries

--- a/orocos_bfl/src/filter/innovationCheck.h
+++ b/orocos_bfl/src/filter/innovationCheck.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __INNOVATION_CHECK__

--- a/orocos_bfl/src/filter/iteratedextendedkalmanfilter.cpp
+++ b/orocos_bfl/src/filter/iteratedextendedkalmanfilter.cpp
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "iteratedextendedkalmanfilter.h"
 

--- a/orocos_bfl/src/filter/iteratedextendedkalmanfilter.h
+++ b/orocos_bfl/src/filter/iteratedextendedkalmanfilter.h
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __ITERATED_EXTENDED_KALMAN_FILTER__

--- a/orocos_bfl/src/filter/kalmanfilter.cpp
+++ b/orocos_bfl/src/filter/kalmanfilter.cpp
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "kalmanfilter.h"
 #include <cmath>

--- a/orocos_bfl/src/filter/kalmanfilter.h
+++ b/orocos_bfl/src/filter/kalmanfilter.h
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __KALMAN_FILTER__

--- a/orocos_bfl/src/filter/mixtureBootstrapFilter.cpp
+++ b/orocos_bfl/src/filter/mixtureBootstrapFilter.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "mixtureBootstrapFilter.h"

--- a/orocos_bfl/src/filter/mixtureBootstrapFilter.h
+++ b/orocos_bfl/src/filter/mixtureBootstrapFilter.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/filter/mixtureParticleFilter.cpp
+++ b/orocos_bfl/src/filter/mixtureParticleFilter.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 // $Id: mixtureParticleFilter.cpp 2009-02-02 tdelaet $
 

--- a/orocos_bfl/src/filter/mixtureParticleFilter.h
+++ b/orocos_bfl/src/filter/mixtureParticleFilter.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/filter/nonminimalkalmanfilter.cpp
+++ b/orocos_bfl/src/filter/nonminimalkalmanfilter.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "nonminimalkalmanfilter.h"
 #include "nonminimal_state/linearise.h"

--- a/orocos_bfl/src/filter/nonminimalkalmanfilter.h
+++ b/orocos_bfl/src/filter/nonminimalkalmanfilter.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __NONMINIMAL_KALMAN_FILTER__

--- a/orocos_bfl/src/filter/optimalimportancefilter.cpp
+++ b/orocos_bfl/src/filter/optimalimportancefilter.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 // $Id$
 

--- a/orocos_bfl/src/filter/optimalimportancefilter.h
+++ b/orocos_bfl/src/filter/optimalimportancefilter.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/filter/particlefilter.cpp
+++ b/orocos_bfl/src/filter/particlefilter.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 // $Id$
 

--- a/orocos_bfl/src/filter/particlefilter.h
+++ b/orocos_bfl/src/filter/particlefilter.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/model/analyticmeasurementmodel_gaussianuncertainty.cpp
+++ b/orocos_bfl/src/model/analyticmeasurementmodel_gaussianuncertainty.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "analyticmeasurementmodel_gaussianuncertainty.h"

--- a/orocos_bfl/src/model/analyticmeasurementmodel_gaussianuncertainty.h
+++ b/orocos_bfl/src/model/analyticmeasurementmodel_gaussianuncertainty.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __MEASUREMENT_MODEL_GAUSSIANUNCERTAINTY__
 #define __MEASUREMENT_MODEL_GAUSSIANUNCERTAINTY__

--- a/orocos_bfl/src/model/analyticsystemmodel_gaussianuncertainty.cpp
+++ b/orocos_bfl/src/model/analyticsystemmodel_gaussianuncertainty.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "analyticsystemmodel_gaussianuncertainty.h"

--- a/orocos_bfl/src/model/analyticsystemmodel_gaussianuncertainty.h
+++ b/orocos_bfl/src/model/analyticsystemmodel_gaussianuncertainty.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __SYSTEM_MODEL_GAUSSIANUNCERTAINTY__
 #define __SYSTEM_MODEL_GAUSSIANUNCERTAINTY__

--- a/orocos_bfl/src/model/discretesystemmodel.cpp
+++ b/orocos_bfl/src/model/discretesystemmodel.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "discretesystemmodel.h"
 

--- a/orocos_bfl/src/model/discretesystemmodel.h
+++ b/orocos_bfl/src/model/discretesystemmodel.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __DISCRETE_SYSTEM_MODEL__
 #define __DISCRETE_SYSTEM_MODEL__

--- a/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty.cpp
+++ b/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "linearanalyticmeasurementmodel_gaussianuncertainty.h"

--- a/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty.h
+++ b/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __LINEAR_MEASUREMENT_MODEL_GAUSSIAN_UNCERTAINTY__
 #define __LINEAR_MEASUREMENT_MODEL_GAUSSIAN_UNCERTAINTY__

--- a/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty_implicit.cpp
+++ b/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty_implicit.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "linearanalyticmeasurementmodel_gaussianuncertainty_implicit.h"

--- a/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty_implicit.h
+++ b/orocos_bfl/src/model/linearanalyticmeasurementmodel_gaussianuncertainty_implicit.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __LINEAR_MEASUREMENT_MODEL_GAUSSIAN_UNCERTAINTY_IMPLICIT__
 #define __LINEAR_MEASUREMENT_MODEL_GAUSSIAN_UNCERTAINTY_IMPLICIT__

--- a/orocos_bfl/src/model/linearanalyticsystemmodel_gaussianuncertainty.cpp
+++ b/orocos_bfl/src/model/linearanalyticsystemmodel_gaussianuncertainty.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../sample/sample.h"

--- a/orocos_bfl/src/model/linearanalyticsystemmodel_gaussianuncertainty.h
+++ b/orocos_bfl/src/model/linearanalyticsystemmodel_gaussianuncertainty.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __LINEAR_ANALYTIC_SYSTEM_MODEL_GAUSSIAN_UNCERTAINTY__
 #define __LINEAR_ANALYTIC_SYSTEM_MODEL_GAUSSIAN_UNCERTAINTY__

--- a/orocos_bfl/src/model/measurementmodel.cpp
+++ b/orocos_bfl/src/model/measurementmodel.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "measurementmodel.h"

--- a/orocos_bfl/src/model/measurementmodel.h
+++ b/orocos_bfl/src/model/measurementmodel.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 //

--- a/orocos_bfl/src/model/nonlinearanalyticmeasurementmodel_gaussianuncertainty_ginac.cpp
+++ b/orocos_bfl/src/model/nonlinearanalyticmeasurementmodel_gaussianuncertainty_ginac.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../sample/sample.h"

--- a/orocos_bfl/src/model/nonlinearanalyticmeasurementmodel_gaussianuncertainty_ginac.h
+++ b/orocos_bfl/src/model/nonlinearanalyticmeasurementmodel_gaussianuncertainty_ginac.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __NON_LINEAR_MEASUREMENT_MODEL_GAUSSIAN_UNCERTAINTY_GINAC__
 #define __NON_LINEAR_MEASUREMENT_MODEL_GAUSSIAN_UNCERTAINTY_GINAC__

--- a/orocos_bfl/src/model/nonlinearanalyticsystemmodel_gaussianuncertainty_ginac.cpp
+++ b/orocos_bfl/src/model/nonlinearanalyticsystemmodel_gaussianuncertainty_ginac.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../sample/sample.h"

--- a/orocos_bfl/src/model/nonlinearanalyticsystemmodel_gaussianuncertainty_ginac.h
+++ b/orocos_bfl/src/model/nonlinearanalyticsystemmodel_gaussianuncertainty_ginac.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __NON_LINEAR_SYSTEM_MODEL_GAUSSIAN_UNCERTAINTY_GINAC__

--- a/orocos_bfl/src/model/systemmodel.cpp
+++ b/orocos_bfl/src/model/systemmodel.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "systemmodel.h"
 

--- a/orocos_bfl/src/model/systemmodel.h
+++ b/orocos_bfl/src/model/systemmodel.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 #ifndef __SYSTEM_MODEL__

--- a/orocos_bfl/src/pdf/EKF_proposaldensity.cpp
+++ b/orocos_bfl/src/pdf/EKF_proposaldensity.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "EKF_proposaldensity.h"

--- a/orocos_bfl/src/pdf/EKF_proposaldensity.h
+++ b/orocos_bfl/src/pdf/EKF_proposaldensity.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __EKF_PROP_DENSITY__

--- a/orocos_bfl/src/pdf/analyticconditionalgaussian.cpp
+++ b/orocos_bfl/src/pdf/analyticconditionalgaussian.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "analyticconditionalgaussian.h"

--- a/orocos_bfl/src/pdf/analyticconditionalgaussian.h
+++ b/orocos_bfl/src/pdf/analyticconditionalgaussian.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __ANALYTIC_CONDITIONAL_GAUSSIAN__

--- a/orocos_bfl/src/pdf/analyticconditionalgaussian_additivenoise.cpp
+++ b/orocos_bfl/src/pdf/analyticconditionalgaussian_additivenoise.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "analyticconditionalgaussian_additivenoise.h"

--- a/orocos_bfl/src/pdf/analyticconditionalgaussian_additivenoise.h
+++ b/orocos_bfl/src/pdf/analyticconditionalgaussian_additivenoise.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __ANALYTIC_CONDITIONAL_GAUSSIAN_ADDITIVE_NOISE__

--- a/orocos_bfl/src/pdf/conditionalgaussian.cpp
+++ b/orocos_bfl/src/pdf/conditionalgaussian.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "conditionalgaussian.h"

--- a/orocos_bfl/src/pdf/conditionalgaussian.h
+++ b/orocos_bfl/src/pdf/conditionalgaussian.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __CONDITIONAL_GAUSSIAN__

--- a/orocos_bfl/src/pdf/conditionalgaussian_additivenoise.cpp
+++ b/orocos_bfl/src/pdf/conditionalgaussian_additivenoise.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "conditionalgaussian_additivenoise.h"

--- a/orocos_bfl/src/pdf/conditionalgaussian_additivenoise.h
+++ b/orocos_bfl/src/pdf/conditionalgaussian_additivenoise.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __CONDITIONAL_GAUSSIAN_ADDITIVE_NOISE__

--- a/orocos_bfl/src/pdf/conditionalpdf.h
+++ b/orocos_bfl/src/pdf/conditionalpdf.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 #ifndef __CONDITIONAL_PDF__

--- a/orocos_bfl/src/pdf/discreteconditionalpdf.cpp
+++ b/orocos_bfl/src/pdf/discreteconditionalpdf.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "discreteconditionalpdf.h"
 #include "../wrappers/rng/rng.h"

--- a/orocos_bfl/src/pdf/discreteconditionalpdf.h
+++ b/orocos_bfl/src/pdf/discreteconditionalpdf.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __DISCRETE_CONDITIONAL_PDF__

--- a/orocos_bfl/src/pdf/discretepdf.cpp
+++ b/orocos_bfl/src/pdf/discretepdf.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "discretepdf.h"
 #include "../bfl_err.h"

--- a/orocos_bfl/src/pdf/discretepdf.h
+++ b/orocos_bfl/src/pdf/discretepdf.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef DISCRETEPDF_H
 #define DISCRETEPDF_H

--- a/orocos_bfl/src/pdf/filterproposaldensity.cpp
+++ b/orocos_bfl/src/pdf/filterproposaldensity.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "filterproposaldensity.h"

--- a/orocos_bfl/src/pdf/filterproposaldensity.h
+++ b/orocos_bfl/src/pdf/filterproposaldensity.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __FILTER_PROP_DENSITY__

--- a/orocos_bfl/src/pdf/gaussian.cpp
+++ b/orocos_bfl/src/pdf/gaussian.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "gaussian.h"
 

--- a/orocos_bfl/src/pdf/gaussian.h
+++ b/orocos_bfl/src/pdf/gaussian.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef GAUSSIAN_H
 #define GAUSSIAN_H

--- a/orocos_bfl/src/pdf/linearanalyticconditionalgaussian.cpp
+++ b/orocos_bfl/src/pdf/linearanalyticconditionalgaussian.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "linearanalyticconditionalgaussian.h"

--- a/orocos_bfl/src/pdf/linearanalyticconditionalgaussian.h
+++ b/orocos_bfl/src/pdf/linearanalyticconditionalgaussian.h
@@ -15,7 +15,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __LINEAR_SYSTEM_CONDITIONAL_GAUSSIAN__

--- a/orocos_bfl/src/pdf/mcpdf.cpp
+++ b/orocos_bfl/src/pdf/mcpdf.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 // This file only contains template specialisation code

--- a/orocos_bfl/src/pdf/mcpdf.h
+++ b/orocos_bfl/src/pdf/mcpdf.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 #ifndef MCPDF_H

--- a/orocos_bfl/src/pdf/mixture.cpp
+++ b/orocos_bfl/src/pdf/mixture.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 // This file only contains template specialisation code

--- a/orocos_bfl/src/pdf/mixture.h
+++ b/orocos_bfl/src/pdf/mixture.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 #ifndef MIXTURE_H

--- a/orocos_bfl/src/pdf/nonlinearanalyticconditionalgaussian_ginac.cpp
+++ b/orocos_bfl/src/pdf/nonlinearanalyticconditionalgaussian_ginac.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "nonlinearanalyticconditionalgaussian_ginac.h"

--- a/orocos_bfl/src/pdf/nonlinearanalyticconditionalgaussian_ginac.h
+++ b/orocos_bfl/src/pdf/nonlinearanalyticconditionalgaussian_ginac.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __NONLINEAR_SYSTEM_CONDITIONAL_GAUSSIAN_GINAC__

--- a/orocos_bfl/src/pdf/optimal_importance_density.cpp
+++ b/orocos_bfl/src/pdf/optimal_importance_density.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "optimal_importance_density.h"

--- a/orocos_bfl/src/pdf/optimal_importance_density.h
+++ b/orocos_bfl/src/pdf/optimal_importance_density.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __OPTIMAL_IMPORTANCE_DENSITY__

--- a/orocos_bfl/src/pdf/pdf.h
+++ b/orocos_bfl/src/pdf/pdf.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 #ifndef PDF_H

--- a/orocos_bfl/src/pdf/uniform.cpp
+++ b/orocos_bfl/src/pdf/uniform.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "uniform.h"
 

--- a/orocos_bfl/src/pdf/uniform.h
+++ b/orocos_bfl/src/pdf/uniform.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef UNIFORM_H
 #define UNIFORM_H

--- a/orocos_bfl/src/sample/sample.cpp
+++ b/orocos_bfl/src/sample/sample.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 // This file only contains template specialisation code

--- a/orocos_bfl/src/sample/sample.h
+++ b/orocos_bfl/src/sample/sample.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 #ifndef SAMPLE_H

--- a/orocos_bfl/src/sample/weightedsample.h
+++ b/orocos_bfl/src/sample/weightedsample.h
@@ -23,8 +23,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 //

--- a/orocos_bfl/src/smoother/backwardfilter.cpp
+++ b/orocos_bfl/src/smoother/backwardfilter.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "backwardfilter.h"

--- a/orocos_bfl/src/smoother/backwardfilter.h
+++ b/orocos_bfl/src/smoother/backwardfilter.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/smoother/particlesmoother.cpp
+++ b/orocos_bfl/src/smoother/particlesmoother.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "particlesmoother.h"

--- a/orocos_bfl/src/smoother/particlesmoother.h
+++ b/orocos_bfl/src/smoother/particlesmoother.h
@@ -24,8 +24,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public             *
  *   License along with this library; if not, write to the Free Software   *
- *   Foundation, Inc., 59 Temple Place,                                    *
- *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                                    *
+ *   Boston, MA  02110-1301  USA                                *
  *                                                                         *
  ***************************************************************************/
 

--- a/orocos_bfl/src/smoother/rauchtungstriebel.cpp
+++ b/orocos_bfl/src/smoother/rauchtungstriebel.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "rauchtungstriebel.h"
 #include <cmath>

--- a/orocos_bfl/src/smoother/rauchtungstriebel.h
+++ b/orocos_bfl/src/smoother/rauchtungstriebel.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef __RAUCHTUNGSTRIEBEL__

--- a/orocos_bfl/src/wrappers/matrix/matrix_BOOST.cpp
+++ b/orocos_bfl/src/wrappers/matrix/matrix_BOOST.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/matrix_BOOST.h
+++ b/orocos_bfl/src/wrappers/matrix/matrix_BOOST.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "../config.h"
 #ifdef __MATRIXWRAPPER_BOOST__

--- a/orocos_bfl/src/wrappers/matrix/matrix_NEWMAT.cpp
+++ b/orocos_bfl/src/wrappers/matrix/matrix_NEWMAT.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/matrix_NEWMAT.h
+++ b/orocos_bfl/src/wrappers/matrix/matrix_NEWMAT.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/matrix_wrapper.h
+++ b/orocos_bfl/src/wrappers/matrix/matrix_wrapper.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __MATRIX_WRAPPER__
 #define __MATRIX_WRAPPER__

--- a/orocos_bfl/src/wrappers/matrix/vector_BOOST.cpp
+++ b/orocos_bfl/src/wrappers/matrix/vector_BOOST.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/vector_BOOST.h
+++ b/orocos_bfl/src/wrappers/matrix/vector_BOOST.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/vector_NEWMAT.cpp
+++ b/orocos_bfl/src/wrappers/matrix/vector_NEWMAT.cpp
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/vector_NEWMAT.h
+++ b/orocos_bfl/src/wrappers/matrix/vector_NEWMAT.h
@@ -14,7 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "../config.h"

--- a/orocos_bfl/src/wrappers/matrix/vector_wrapper.h
+++ b/orocos_bfl/src/wrappers/matrix/vector_wrapper.h
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #ifndef __OROVECTOR__
 #define __OROVECTOR__

--- a/orocos_bfl/src/wrappers/rng/rng.cpp
+++ b/orocos_bfl/src/wrappers/rng/rng.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 #include "rng.h"
 

--- a/orocos_bfl/src/wrappers/rng/rng.h
+++ b/orocos_bfl/src/wrappers/rng/rng.h
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 // Wrapper around several Pseudo RNG-libraries
 #ifndef __ORO_PSEUDORNG__

--- a/orocos_bfl/tests/approxEqual.cpp
+++ b/orocos_bfl/tests/approxEqual.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "approxEqual.hpp"

--- a/orocos_bfl/tests/approxEqual.hpp
+++ b/orocos_bfl/tests/approxEqual.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef APPROX_EQUAL_HPP

--- a/orocos_bfl/tests/complete_filter_test.cpp
+++ b/orocos_bfl/tests/complete_filter_test.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 

--- a/orocos_bfl/tests/complete_filter_test.hpp
+++ b/orocos_bfl/tests/complete_filter_test.hpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef COMPLETE_FILTER_TEST_HPP

--- a/orocos_bfl/tests/ekf_test.cpp
+++ b/orocos_bfl/tests/ekf_test.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "ekf_test.hpp"

--- a/orocos_bfl/tests/ekf_test.hpp
+++ b/orocos_bfl/tests/ekf_test.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef EKF_TEST_HPP

--- a/orocos_bfl/tests/matrixwrapper_test.cpp
+++ b/orocos_bfl/tests/matrixwrapper_test.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 

--- a/orocos_bfl/tests/matrixwrapper_test.hpp
+++ b/orocos_bfl/tests/matrixwrapper_test.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef MATRIXWRAPPER_TEST_HPP

--- a/orocos_bfl/tests/model_test.cpp
+++ b/orocos_bfl/tests/model_test.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "model_test.hpp"

--- a/orocos_bfl/tests/model_test.hpp
+++ b/orocos_bfl/tests/model_test.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef MODEL_TEST_HPP

--- a/orocos_bfl/tests/model_test_ginac.cpp
+++ b/orocos_bfl/tests/model_test_ginac.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "model_test_ginac.hpp"

--- a/orocos_bfl/tests/model_test_ginac.hpp
+++ b/orocos_bfl/tests/model_test_ginac.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef MODEL_TEST_GINAC_HPP

--- a/orocos_bfl/tests/pdf_test.cpp
+++ b/orocos_bfl/tests/pdf_test.cpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "pdf_test.hpp"

--- a/orocos_bfl/tests/pdf_test.hpp
+++ b/orocos_bfl/tests/pdf_test.hpp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef PDF_TEST_HPP

--- a/orocos_bfl/tests/sample_test.cpp
+++ b/orocos_bfl/tests/sample_test.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "sample_test.hpp"

--- a/orocos_bfl/tests/sample_test.hpp
+++ b/orocos_bfl/tests/sample_test.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef SAMPLE_TEST_HPP

--- a/orocos_bfl/tests/smoother_test.cpp
+++ b/orocos_bfl/tests/smoother_test.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #include "smoother_test.hpp"

--- a/orocos_bfl/tests/smoother_test.hpp
+++ b/orocos_bfl/tests/smoother_test.hpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 #ifndef SMOOTHER_TEST_HPP

--- a/orocos_bfl/tests/test-runner.cpp
+++ b/orocos_bfl/tests/test-runner.cpp
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
 //
 
 /* Modified from orocos cppunit test code, also published under GPLV2


### PR DESCRIPTION
The FSF address has changed a while ago, the new address is taken from
the license template at
https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html.